### PR TITLE
The Face FEA construct identifies surfaces for placing loads/constrai…

### DIFF
--- a/deploy/CAD_Installs/packages.config
+++ b/deploy/CAD_Installs/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- n.b the last component of the versions is ignored, and replaced with the last svn modification revision -->
 <packages>
-  <package id="META.CadCreoParametricCreateAssembly" version="1.5.5.0" />
+  <package id="META.CadCreoParametricCreateAssembly" version="1.5.6.0" />
   
   <package id="META.ExtractACM-XMLfromCreoModels" version="1.5.2.0" />
   

--- a/src/CADAssembler/CADCreoParametricCreateAssembly/0Readme - CreateAssembly.txt
+++ b/src/CADAssembler/CADCreoParametricCreateAssembly/0Readme - CreateAssembly.txt
@@ -967,14 +967,22 @@ v1.5.5.0 04/04/2016	GitHub Branch: CAD_003_Support_FEA_CAD_GEOMETRY_NONE
 			This resulted in error messages such as “For a polygon load, there must at least three 
 			features (i.e. Datum Points)”.  This defect was corrected to support acceleration and 
 			ambient temperature loads correctly.
+			R.O.
 
 			
-			
+v1.5.6.0 04/13/2016	GitHub Branch: CAD_004_Correct_FEA_Treatment_of_Assembly_Surfaces
+	
+			The Face FEA construct identifies surfaces for placing loads/constraints.  For 
+			deck-based FEA this worked correctly for single parts, but not for assemblies 
+			of parts.  For assemblies, parts are offset from the assembly global coordinate 
+			system and special transformations were needed for the Face construct to work 
+			properly for assemblies.
+			R.O.
 
 Known Defects
 -------------
 
-1. 	Title: 			Error with Multiple Instances of a Parametric Family Table Part
+1. 	Title: 			Error with Multiple Insta Parametric Family Table Part
    	Date Found: 		7/27/2012
 	Found in Version: 	v1.3.5.0
 	Description: 		Multiple instances of a parametric family table part results in the following error:

--- a/src/CADAssembler/CADCreoParametricCreateAssembly/ISISVersionNumber.h
+++ b/src/CADAssembler/CADCreoParametricCreateAssembly/ISISVersionNumber.h
@@ -1,7 +1,7 @@
 // The rc compiler will not except #ifndef blocks.  Therefore, include this file judiciously.
-#define ISIS_PRODUCT_VERSION  1,5,5,0
+#define ISIS_PRODUCT_VERSION  1,5,6,0
 #define ISIS_FILE_VERSION ISIS_PRODUCT_VERSION
-#define ISIS_STR_PRODUCT_VERSION "CADCreoParametricCreateAssembly 1.5.5.0\0"
-#define ISIS_PRODUCT_VERSION_WITH_v_AND_DOTS "v1.5.5.0"
+#define ISIS_STR_PRODUCT_VERSION "CADCreoParametricCreateAssembly 1.5.6.0\0"
+#define ISIS_PRODUCT_VERSION_WITH_v_AND_DOTS "v1.5.6.0"
 #define ISIS_CYPHY_2_CAD_DLL_MIN_VERSION "1.2.0.0"
 #define ISIS_METRIC_FILE_VERSION "v1.1.0.0"


### PR DESCRIPTION
…nts.  For deck-based FEA this worked correctly for single parts, but not for assemblies of parts.  For assemblies, parts are offset from the assembly global coordinate system and special transformations were needed for the Face construct to work properly for assemblies.