### PR TITLE
Fix CAD Assembly crash if there are Test Bench parameters but no CAD parameters

### DIFF
--- a/src/CyPhy2CAD_CSharp/Resources/PETUpdateCADParameter.py
+++ b/src/CyPhy2CAD_CSharp/Resources/PETUpdateCADParameter.py
@@ -56,16 +56,22 @@ class Layout_to_CadAssembly(object):
         if 'Parameters' in tbmanifest_dict:
             self.tbmanifest_param_list = tbmanifest_dict['Parameters']
             
-        cadparam_mapping_list = self.parse_json(self.testbench_cadparam_json)
-        for cadparam in cadparam_mapping_list:
-            if 'TestBenchParameterName' in cadparam:
-                value = self.find_testbench_param_value(cadparam['TestBenchParameterName'])
-                if value is not None:               
-                    if cadparam['ComponentInstanceGUID'] not in instanceguid_param_dict:
-                        instanceguid_param_dict[cadparam['ComponentInstanceGUID']] = {}
-                        
-                    instanceguid_param_dict[cadparam['ComponentInstanceGUID']][cadparam['CADParameterName']] = value
-                    print instanceguid_param_dict
+        if not os.path.isfile(self.testbench_cadparam_json):
+            # There are no CAD parameters, even though there are TestBench parameters, so move along.
+            pass
+        else:
+            # Map the TestBench parameters to CAD parameters
+            cadparam_mapping_list = self.parse_json(self.testbench_cadparam_json)
+            for cadparam in cadparam_mapping_list:
+                if 'TestBenchParameterName' in cadparam:
+                    value = self.find_testbench_param_value(cadparam['TestBenchParameterName'])
+                    if value is not None:
+                        if cadparam['ComponentInstanceGUID'] not in instanceguid_param_dict:
+                            instanceguid_param_dict[cadparam['ComponentInstanceGUID']] = {}
+
+                        instanceguid_param_dict[cadparam['ComponentInstanceGUID']][cadparam['CADParameterName']] = value
+                        print instanceguid_param_dict
+
         return instanceguid_param_dict
                 
     def find_testbench_param_value(self, param_name):

--- a/src/Python27Packages/run_mdao/cad/__init__.py
+++ b/src/Python27Packages/run_mdao/cad/__init__.py
@@ -37,16 +37,21 @@ class TestBenchParameter_to_CadAssembly(object):
         if 'Parameters' in tbmanifest_dict:
             self.tbmanifest_param_list = tbmanifest_dict['Parameters']
             self.logger.info(self.tbmanifest_param_list)
-        cadparam_mapping_list = self._parse_json(self.testbench_cadparam_json)
-        for cadparam in cadparam_mapping_list:
-            if 'TestBenchParameterName' in cadparam:
-                value = self._find_testbench_param_value(cadparam['TestBenchParameterName'])
-                if value is not None:
-                    if cadparam['ComponentInstanceGUID'] not in instanceguid_param_dict:
-                        instanceguid_param_dict[cadparam['ComponentInstanceGUID']] = {}
 
-                    instanceguid_param_dict[cadparam['ComponentInstanceGUID']][cadparam['ComponentCADParameterName']] = value
-                    self.logger.info('instanceguid_param_dict : {0}'.format(instanceguid_param_dict))
+        if not os.path.isfile(self.testbench_cadparam_json):
+            # There are no CAD parameters, even though there are TestBench parameters, so move along.
+            pass
+        else:
+            cadparam_mapping_list = self._parse_json(self.testbench_cadparam_json)
+            for cadparam in cadparam_mapping_list:
+                if 'TestBenchParameterName' in cadparam:
+                    value = self._find_testbench_param_value(cadparam['TestBenchParameterName'])
+                    if value is not None:
+                        if cadparam['ComponentInstanceGUID'] not in instanceguid_param_dict:
+                            instanceguid_param_dict[cadparam['ComponentInstanceGUID']] = {}
+
+                        instanceguid_param_dict[cadparam['ComponentInstanceGUID']][cadparam['ComponentCADParameterName']] = value
+                        self.logger.info('instanceguid_param_dict : {0}'.format(instanceguid_param_dict))
 
         return instanceguid_param_dict
 


### PR DESCRIPTION
This situation arose when I had a CAD Test Bench that had a parameter, but that parameter didn't map to a CAD model. This would result in a crash because the Python file would look for `CADParamTestBenchMapping.json` but **CyPhy2CAD_CSharp** wouldn't create it. 

I created this Test Bench mostly to fool the PET driver, which requires you to hook up a parameter, but this seemed like a better fallback for that case.