### PR TITLE
CAD.vcxproj will not compile with Visual Studio (VS) 2015 unless VS 2…

### DIFF
--- a/meta/CAD/CAD.vcxproj
+++ b/meta/CAD/CAD.vcxproj
@@ -16,6 +16,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v110</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
…010 is installed.   Since VS 2012 is required for Creo, upgrade this project to VS 2012.