### PR TITLE
Corrected the bug that for a “Structural FEA Test Bench”, the Referen…

### DIFF
--- a/deploy/CAD_Installs/Proe ISIS Extensions/0ReadMe - CyPhy2CAD_CSharp.txt
+++ b/deploy/CAD_Installs/Proe ISIS Extensions/0ReadMe - CyPhy2CAD_CSharp.txt
@@ -6,7 +6,7 @@ Revision History:
 ----------------
 
 
-	  3/15/2016  	Export_All_Component_Points: Added the capability to export all component points by 
+	3/15/2016  	Export_All_Component_Points: Added the capability to export all component points by 
            		specifying a particular parameter in the Test Bench.  Typically, to export a component 
            		point there would need to be a metric in the Test Bench that pointed to a point in 
            		a referenced component (e.g. System Under Test).   With this change, if a parameter 
@@ -17,4 +17,11 @@ Revision History:
            		Note – Only the points in the component (Kind = Component) would be exported and not 
            		the points in CADModel (Kind = CADModel) unless those points were exposed at the component level. 
 
-V2.0.0.0 ??/??/??	Added version to CyPhy2CAD_CSharp.dll.  ???Other changes???
+	1/18/2017       CAD_019_Correct_CyPhy2CAD_ReferenceCoordinateSystem_Error
+			Corrected the following bug:
+				For a “Structural FEA Test Bench”, the ReferenceCoordinateSystem are being 
+				ignored for the case where the TestInjectionPoints are Components 
+				(i.e. not ComponentAssemblies).   If there was a mix of Components and 
+				ComponentAssemblies in the TB, then any ReferenceCoordinateSystems in the 
+				Components would be ignored.
+			R.O.

--- a/src/CyPhy2CAD_CSharp/EdgeWalker.cs
+++ b/src/CyPhy2CAD_CSharp/EdgeWalker.cs
@@ -463,6 +463,11 @@ namespace CyPhy2CAD_CSharp
                 }
             }
 
+            if (start_id == "-1")
+            {
+                Logger.Instance.AddLogMessage("No referencecoordinatesystem was found. Root component of assembly will be selected arbitrarily.", Severity.Warning);
+            }
+
             int degrees = 6;
             while (start_id == "-1" && degrees > 2)		// if not in RefCoordSystemComponentIDs_in
             {
@@ -535,6 +540,7 @@ namespace CyPhy2CAD_CSharp
 
             if (start_id == "-1")
                 start_id = components.First();
+
 
             foreach (var item in components)
             {


### PR DESCRIPTION
…ceCoordinateSystem are being ignored for the case where the TestInjectionPoints are Components (i.e. not ComponentAssemblies).   If there was a mix of Components and ComponentAssemblies in the TB, then any ReferenceCoordinateSystems in the Components would be ignored.