### PR TITLE
OPENMETA-105 Add GenericDomainModelPort to the ConnectorUnroller whitelist

### DIFF
--- a/src/CyPhyElaborateCS/ConnectorUnroller.cs
+++ b/src/CyPhyElaborateCS/ConnectorUnroller.cs
@@ -105,7 +105,8 @@ namespace CyPhyElaborateCS
             "AbstractPort",
             "BondGraphPort",
             "ModelicaConnector",
-            "SimulinkPort"
+            "SimulinkPort",
+            "GenericDomainModelPort"
         };
 
         /// <summary>


### PR DESCRIPTION
Per OPENMETA-105, `GenericDomainModelPort`s aren't supported by the ConnectorUnroller in CyPhyElaborateCS; this adds them to the whitelist of supported port types.

(This is needed by the [openmeta-simulink](https://github.com/metamorph-inc/openmeta-simulink) Python domain tool integration example, which uses `GenericDomainModel` and `GenericDomainModelPort` to integrate Simulink without making model changes in META.)