### PR TITLE
Added support for exporting DXF format.  Exporting Wavefront is not s…

### DIFF
--- a/deploy/CAD_Installs/Proe ISIS Extensions/0ReadMe - CyPhy2CAD_CSharp.txt
+++ b/deploy/CAD_Installs/Proe ISIS Extensions/0ReadMe - CyPhy2CAD_CSharp.txt
@@ -38,3 +38,6 @@ Revision History:
 				EXPORT_INVENTOR
 				EXPORT_PARASOLID
 			R.O.
+
+	5/11/2017	Added support for exporting DXF formats based on the Test Bench parameter 
+			EXPORT_DXF_2013. 

--- a/deploy/CAD_Installs/packages.config
+++ b/deploy/CAD_Installs/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- n.b the last component of the versions is ignored, and replaced with the last svn modification revision -->
 <packages>
-  <package id="META.CadCreoParametricCreateAssembly" version="1.5.14.0" />
+  <package id="META.CadCreoParametricCreateAssembly" version="1.5.15.0" />
   
   <package id="META.ExtractACM-XMLfromCreoModels" version="1.5.2.0" />
   

--- a/src/CADAssembler/CADCommonFunctions/CADStringToEnumConversions.cpp
+++ b/src/CADAssembler/CADCommonFunctions/CADStringToEnumConversions.cpp
@@ -1027,6 +1027,8 @@ namespace isis
 		  else if ( DataExchangeFormat.compare("STEREOLITHOGRAPHY") == 0 )	return DATA_EXCHANGE_FORMAT_STEREOLITHOGRAPHY;
 		  else if ( DataExchangeFormat.compare("INVENTOR") == 0 )	        return DATA_EXCHANGE_FORMAT_INVENTOR;	
 		  else if ( DataExchangeFormat.compare("PARASOLID") == 0 )	        return DATA_EXCHANGE_FORMAT_PARASOLID;
+		  else if ( DataExchangeFormat.compare("DXF") == 0 )				return DATA_EXCHANGE_DXF;
+		  // else if ( DataExchangeFormat.compare("WAVEFRONT") == 0 )			return DATA_EXCHANGE_WAVEFRONT; Wavefront export not supported as of Creo 3.0, See Creo Support document CS249920
 		  
 
 		  string temp_string = "Function DataExchangeFormat_enum was passed " + in_DataExchangeFormat_string + " which is an erroneous type.";
@@ -1051,11 +1053,17 @@ namespace isis
 			case DATA_EXCHANGE_FORMAT_PARASOLID:
 				return "PARASOLID";
 				break;
+			case DATA_EXCHANGE_DXF:
+				return "DXF";
+				break;
+			//case DATA_EXCHANGE_WAVEFRONT:  Wavefront export not supported as of Creo 3.0, See Creo Support document CS249920
+			//	return "WAVEFRONT";
+			//	break;
 			default:
 				char temp_char_array[ISIS_CHAR_BUFFER_LENGTH];
 				string temp_string = "Function DataExchangeFormat_string was passed " + 
 					std::string(_itoa(in_DataExchangeFormat_enum, temp_char_array, 10)) + 
-					" which is an erroneous type.  Allowed enum value DATA_EXCHANGE_FORMAT_STEP, DATA_EXCHANGE_FORMAT_STEREOLITHOGRAPHY, and DATA_EXCHANGE_FORMAT_INVENTOR.";
+					" which is an erroneous type.  Allowed enum value DATA_EXCHANGE_FORMAT_STEP, DATA_EXCHANGE_FORMAT_STEREOLITHOGRAPHY, DATA_EXCHANGE_FORMAT_INVENTOR, and DATA_EXCHANGE_DXF.";
 				throw isis::application_exception(temp_string.c_str());
 		}
 	}
@@ -1076,7 +1084,9 @@ namespace isis
 		  else if ( DataExchangeVersion_string.compare("AP214_SEPARATE_PART_FILES") == 0 )		return AP214_SEPARATE_PART_FILES;
 		  else if ( DataExchangeVersion_string.compare("ASCII") == 0 )							return ASCII;
 		  else if ( DataExchangeVersion_string.compare("BINARY") == 0 )							return BINARY;
-		 
+		  else if ( DataExchangeVersion_string.compare("2013") == 0 )							return Y2013;
+	
+
 		  string temp_string = "Function DataExchangeVersion_enum was passed " + in_DataExchangeVersion_string + " which is an erroneous type.";
 		  throw isis::application_exception(temp_string.c_str());
 	 }
@@ -1111,11 +1121,14 @@ namespace isis
 			case BINARY:
 				return "BINARY";
 				break;
+			case Y2013:
+				return "2013";
+				break;
 			default:
 				char temp_char_array[ISIS_CHAR_BUFFER_LENGTH];
 				string temp_string = "Function DataExchangeVersion_string was passed " + 
 					std::string(_itoa(in_DataExchangeVersion_enum, temp_char_array, 10)) + 
-					" which is an erroneous type.  Allowed enum values are DATA_EXCHANGE_VERSION_NOT_APPLICABLE, AP203_SINGLE_FILE, AP203_E2_SINGLE_FILE, AP203_E2_SEPARATE_PART_FILES, AP214_SINGLE_FILE, AP214_SEPARATE_PART_FILES, STEREOLITHOGRAPHY_ASCII and STEREOLITHOGRAPHY_BINARY.";
+					" which is an erroneous type.  Allowed enum values are DATA_EXCHANGE_VERSION_NOT_APPLICABLE, AP203_SINGLE_FILE, AP203_E2_SINGLE_FILE, AP203_E2_SEPARATE_PART_FILES, AP214_SINGLE_FILE, AP214_SEPARATE_PART_FILES, STEREOLITHOGRAPHY_ASCII, STEREOLITHOGRAPHY_BINARY, and Y2013.";
 				throw isis::application_exception(temp_string.c_str());
 	  }
 	}

--- a/src/CADAssembler/CADCommonFunctions/CADStringToEnumConversions.h
+++ b/src/CADAssembler/CADCommonFunctions/CADStringToEnumConversions.h
@@ -393,7 +393,10 @@ namespace isis
         DATA_EXCHANGE_FORMAT_STEP,
 		DATA_EXCHANGE_FORMAT_STEREOLITHOGRAPHY,  //STL
 		DATA_EXCHANGE_FORMAT_INVENTOR,
-		DATA_EXCHANGE_FORMAT_PARASOLID
+		DATA_EXCHANGE_FORMAT_PARASOLID,
+		DATA_EXCHANGE_DXF
+		// DATA_EXCHANGE_WAVEFRONT,   Wavefront export not supported as of Creo 3.0, See Creo Support document CS249920
+
     };	
 
 	e_DataExchangeFormat	DataExchangeFormat_enum( 
@@ -413,6 +416,7 @@ namespace isis
 		AP214_SEPARATE_PART_FILES,
 		ASCII,
 		BINARY,
+		Y2013     // Applies only to DXF
     };	
 
 	 e_DataExchangeVersion	DataExchangeVersion_enum( 

--- a/src/CADAssembler/CADCreoParametricCreateAssembly/0Readme - CreateAssembly.txt
+++ b/src/CADAssembler/CADCreoParametricCreateAssembly/0Readme - CreateAssembly.txt
@@ -1046,6 +1046,12 @@ v1.5.14.0  04/27/2016	Started the refactoring to support other CAD systems.  In 
 			CAD_025_Updates_for_Generic_CAD_Interface
 			R.O.
 
+v1.5.15.0  05/11/2016	Added support for exporting DXF format.  Exporting Wavefront is not supported by the toolkit.
+			DXF exports only work with Solid models.  Surface models will result in a DXF file that is empty.
+ 			Switched from using the Creo function ProOutputFileWrite (deprecated as of Creo 3.0) to ProOutputFileMdlnameWrite.
+			R.O.	
+
+
 Known Defects
 -------------
 

--- a/src/CADAssembler/CADCreoParametricCreateAssembly/DataExchange.cpp
+++ b/src/CADAssembler/CADCreoParametricCreateAssembly/DataExchange.cpp
@@ -247,7 +247,9 @@ void ExportDataExchangeFiles_STEP(
 			//MultiFormatString StepFileName_multiString(StepFileName_string, PRO_FILE_NAME_SIZE - 1 );
 
 		
-			isis_ProOutputFileWrite(	p_Model,
+
+				//isis_ProOutputFileWrite(	p_Model,    // This function was deprecated as of Creo 3.0
+				isis_ProOutputFileMdlnameWrite(	p_Model,
 										StepFileName_string,
 										PRO_STEP_FILE,
 										NULL,
@@ -412,13 +414,184 @@ void ExportDataExchangeFiles_Stereolithography_or_Inventor(
 				ExportFileType = PRO_INVENTOR_FILE;
 			}
 
-			isis_ProOutputFileWrite(	p_Model,
+				//isis_ProOutputFileWrite(	p_Model,   // This function was deprecated as of Creo 3.0
+				isis_ProOutputFileMdlnameWrite(	p_Model,
 										OutputFileName_string,
 										ExportFileType,
 										NULL,
 										&Arg_2,
 										NULL,
 										NULL );
+
+			if ( in_LogProgress )
+			{
+				isis_LOG(lg, isis_CONSOLE_FILE, isis_INFO) << "   Created " << outDirName << " file(s) for "  << in_ModelName;
+			}
+		} // END if ( i.dataExchangeFormat == DATA_EXCHANGE_FORMAT_STEP )
+	}  // END 	for each ( DataExchangeSpecification i in in_DataExchangeSpecifications )
+
+	// Set Creo back to the original working directory.  This would only be necessary
+	// if multiple assemblies were begin created.
+	//std::cout << std::endl << "in_WORKING_DIR: " << in_WORKING_DIR;
+	MultiFormatString originalWorkingDirPath_MultiString( in_WORKING_DIR, PRO_PATH_SIZE - 1 );
+
+	//std::cout << std::endl << "originalWorkingDirPath_MultiString: " << originalWorkingDirPath_MultiString;
+	isis::setCreoWorkingDirectory( originalWorkingDirPath_MultiString );
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ExportDataExchangeFiles_DXF( 
+					const std::string									&in_ComponentInstanceID,
+					const MultiFormatString								&in_ModelName, 
+					ProMdlType											in_ModelType,
+					const isis::MultiFormatString						&in_GeometryRepresentation,
+					const std::string									&in_WORKING_DIR,
+					const std::list<DataExchangeSpecification>          &in_DataExchangeSpecifications,
+					bool												in_LogProgress )
+																	throw (isis::application_exception)
+{
+	ProMdl     p_Model;
+
+
+	isis_ProMdlRetrieve_WithDescriptiveErrorMsg( 
+											// Added Arguments
+											in_ComponentInstanceID,
+											in_ModelName,
+											in_GeometryRepresentation,
+											// Original arguments
+											in_ModelName, 
+											in_ModelType,
+											&p_Model);
+	
+
+
+	for each ( DataExchangeSpecification i in in_DataExchangeSpecifications )
+	{
+		if ( i.dataExchangeFormat == DATA_EXCHANGE_DXF )
+		{
+
+			//////////////////////////
+			// Create the directory
+			//////////////////////////
+			std::string outDirName;
+
+			// Only supporting 2013, if later version become available, must do a switch statement
+			outDirName = "DXF_2013";
+
+			switch ( i.dataExchangeVersion )
+			{
+				case Y2013:
+					outDirName = "DXF_2013";
+					break;
+				default:					
+					std::stringstream errorString;
+					errorString << "Function - " << __FUNCTION__ << ", DXF dataExchangeVersion integer ID: " + i.dataExchangeVersion   << 
+			           ", which is an erroneous type. Allowed types are: " << 
+					   "2013 (ID " << Y2013 << ").";
+					throw isis::application_exception(errorString);		
+			}
+
+
+			std::string createOutDir = "if not exist " +  outDirName +  " mkdir  " + outDirName;
+			isis::ExecuteSystemCommand( createOutDir);
+
+			// Set the Creo directory to the created directory
+			std::string outPathAndDir = in_WORKING_DIR + "\\" + outDirName;
+			MultiFormatString WorkingDirPath_MultiString( outPathAndDir, PRO_PATH_SIZE - 1 );
+
+			setCreoWorkingDirectory(WorkingDirPath_MultiString);  
+
+
+			// Write Data Exchange file (e.g. Stereolithography File)  ??? is this needed
+			//int Arg_2 = 1;
+
+			std::string suffix;
+			suffix = ".dxf";
+
+			//std::string StepFileName_string;
+			MultiFormatString OutputFileName_string;
+
+			OutputFileName_string = (std::string)in_ModelName + suffix;
+
+			ProIntf3DExportType ExportFileType = PRO_INTF_EXPORT_DXF;
+
+			ProName		optionName;
+			ProPath		optionValue;
+			wcscpy( optionName, L"intf3d_out_prop_chord_heights");
+			wcscpy( optionValue, L"yes");
+
+			wcscpy( optionName, L"dxf_export_format");
+			wcscpy( optionValue, L"2013");
+
+			ProBoolean is_supported;
+
+			pro_output_assembly_configuration assembly_configuration  = PRO_OUTPUT_ASSEMBLY_FLAT_FILE;
+			isis_ProOutputAssemblyConfigurationIsSupported( ExportFileType,
+           											assembly_configuration,
+													&is_supported);
+													
+			if ( is_supported == PRO_B_TRUE )
+			{
+				//ProOutputBrepRepresentation representation;
+				//isis_ProOutputBrepRepresentationAlloc( &representation);
+														
+
+				//isis_ProOutputBrepRepresentationFlagsSet(	representation,
+				//											PRO_B_FALSE,   //as_wireframe
+				//											PRO_B_FALSE,    // as_surfaces
+				//											PRO_B_FALSE,   // as_solid
+				//											PRO_B_TRUE);   // as_quilts
+
+				//ProBoolean brepRepresentationFlags_supported;
+				//isis_ProOutputBrepRepresentationIsSupported( ExportFileType, representation, &brepRepresentationFlags_supported);
+
+				//if ( brepRepresentationFlags_supported == PRO_B_FALSE )
+				//{
+				//	stringstream errorMsg_temp;
+				//	errorMsg_temp << "Functions " << __FUNCTION__ << ", ProOutputBrepRepresentationIsSupported flags not supported: " <<
+				//		" as_wireframe == false, surfaces == false, solid = false, quilts = true";
+				//	
+				//	throw isis::application_exception(errorMsg_temp);
+				// }
+
+				//ProOutputInclusion inclusion;
+				//isis_ProOutputInclusionAlloc( &inclusion);
+
+				//isis_ProOutputInclusionFlagsSet( inclusion,
+				//								  PRO_B_FALSE, //		 ProBoolean include_datums,
+				//								  PRO_B_FALSE, //		 ProBoolean include_blanked,
+				//								  PRO_B_TRUE); //		 ProBoolean include_facetted)
+
+				// Suface models are not being exported via DXF. The resulting DXF file is empty.
+				// Setting inclusion and/or representation does not help.
+
+				isis::isis_ProIntf3DFileWrite( (ProSolid)p_Model, 
+												ExportFileType, 
+												(wchar_t*)(const wchar_t*)OutputFileName_string, 
+												assembly_configuration,
+												NULL, NULL, NULL, NULL);
+												//NULL, NULL, inclusion, NULL);
+												//NULL, representation, NULL, NULL);
+
+				//isis_ProOutputBrepRepresentationFree( representation);
+				 //isis_ProOutputInclusionFree (inclusion);
+			}
+			else
+			{
+				stringstream errorMsg_temp;
+				errorMsg_temp << "Failed to create DXF file for: " << (std::string)in_ModelName << 
+					"\n   ProOutputAssemblyConfigurationIsSupported indicated that the DXF format is not supported for the assembly." <<
+					"\n   To reproduce the problem, with Creo open the " << (std::string)in_ModelName << " assembly and try to save it to the DXF format.";
+				ofstream DXF_Failed;
+				DXF_Failed.open (outPathAndDir + "\\_FAILED.txt");
+				DXF_Failed << errorMsg_temp.str();
+				DXF_Failed.close();
+
+				isis_LOG(lg, isis_CONSOLE_FILE, isis_WARN) << errorMsg_temp;
+
+				throw isis::application_exception(errorMsg_temp);
+			}
 
 			if ( in_LogProgress )
 			{
@@ -543,6 +716,8 @@ void ExportDataExchangeFiles(
 	bool Stereolithography_Files_Requested = false;
 	bool Inventor_Files_Requested = false;
 	bool Parasolid_Files_Requested = false;
+	bool DXF_Files_Requested = false;
+	bool Wavefront_Files_Requested = false;
 
 	for each ( DataExchangeSpecification i in in_DataExchangeSpecifications )
 	{
@@ -550,6 +725,7 @@ void ExportDataExchangeFiles(
 		if ( i.dataExchangeFormat == DATA_EXCHANGE_FORMAT_STEREOLITHOGRAPHY ) Stereolithography_Files_Requested = true;
 		if ( i.dataExchangeFormat == DATA_EXCHANGE_FORMAT_INVENTOR ) Inventor_Files_Requested = true;
 		if ( i.dataExchangeFormat == DATA_EXCHANGE_FORMAT_PARASOLID ) Parasolid_Files_Requested = true;
+		if ( i.dataExchangeFormat == DATA_EXCHANGE_DXF ) DXF_Files_Requested = true;
 	}
 
 	if ( STEP_Files_Requested )
@@ -586,6 +762,26 @@ void ExportDataExchangeFiles(
 					true );
 
 	}
+
+	if ( DXF_Files_Requested )
+	{
+		ExportDataExchangeFiles_DXF( in_ComponentInstanceID,
+					in_ModelName, 
+					in_ModelType,
+					in_GeometryRepresentation,
+					in_WORKING_DIR,
+					in_DataExchangeSpecifications,
+					true );
+
+	}
+
+
+	/*****  Wavefront export not supported as of Creo 3.0
+	See 
+	Creo Support Site - See Document CS249910
+	https://support.ptc.com/appserver/cs/view/solution.jsp?n=CS249910&art_lang=en&posno=11&q=ProIntf3DFileWrite&ProductFamily=Creo%20%26%20Pro%2FENGINEER%7CCreo%20Simulate%20%26%20Pro%2FMechanica&source=search
+
+	*********/
 
 
 }
@@ -663,6 +859,8 @@ void ExportDataExchangeFiles(
 	bool Stereolithography_Files_Requested = false;
 	bool Inventor_Files_Requested = false;
 	bool Parasolid_Files_Requested = false;
+	bool DXF_Files_Requested = false;
+	bool Wavefront_Files_Requested = false;
 
 	for each ( DataExchangeSpecification i in in_DataExchangeSpecifications )
 	{
@@ -670,6 +868,7 @@ void ExportDataExchangeFiles(
 		if ( i.dataExchangeFormat == DATA_EXCHANGE_FORMAT_STEREOLITHOGRAPHY ) Stereolithography_Files_Requested = true;
 		if ( i.dataExchangeFormat == DATA_EXCHANGE_FORMAT_INVENTOR ) Inventor_Files_Requested = true;
 		if ( i.dataExchangeFormat == DATA_EXCHANGE_FORMAT_PARASOLID ) Parasolid_Files_Requested = true;
+		if ( i.dataExchangeFormat == DATA_EXCHANGE_DXF ) DXF_Files_Requested = true;
 	}
 
 	if ( STEP_Files_Requested )
@@ -716,6 +915,27 @@ void ExportDataExchangeFiles(
 					in_DataExchangeSpecifications,
 					true );
 	}
+
+	if ( DXF_Files_Requested )
+	{
+		// For now, only export the top assembly.  Do not export individual files.  Currently, there is no requirement to 
+		// export individual files.
+		ExportDataExchangeFiles_DXF( in_ComponentID,
+					in_CADComponentData_map[in_ComponentID].name, 
+					in_CADComponentData_map[in_ComponentID].modelType,
+					in_CADComponentData_map[in_ComponentID].geometryRepresentation,
+					in_WORKING_DIR,
+					in_DataExchangeSpecifications,
+					true );
+	}
+
+
+	/*****  Wavefront export not supported as of Creo 3.0
+	See 
+	Creo Support Site - See Document CS249910
+	https://support.ptc.com/appserver/cs/view/solution.jsp?n=CS249910&art_lang=en&posno=11&q=ProIntf3DFileWrite&ProductFamily=Creo%20%26%20Pro%2FENGINEER%7CCreo%20Simulate%20%26%20Pro%2FMechanica&source=search
+
+	*********/
 
 }
 

--- a/src/CADAssembler/CADCreoParametricCreateAssembly/ISISVersionNumber.h
+++ b/src/CADAssembler/CADCreoParametricCreateAssembly/ISISVersionNumber.h
@@ -1,7 +1,7 @@
 // The rc compiler will not except #ifndef blocks.  Therefore, include this file judiciously.
-#define ISIS_PRODUCT_VERSION  1,5,14,0
+#define ISIS_PRODUCT_VERSION  1,5,15,0
 #define ISIS_FILE_VERSION ISIS_PRODUCT_VERSION
-#define ISIS_STR_PRODUCT_VERSION "CADCreoParametricCreateAssembly 1.5.14.0\0"
-#define ISIS_PRODUCT_VERSION_WITH_v_AND_DOTS "v1.5.14.0"
+#define ISIS_STR_PRODUCT_VERSION "CADCreoParametricCreateAssembly 1.5.15.0\0"
+#define ISIS_PRODUCT_VERSION_WITH_v_AND_DOTS "v1.5.15.0"
 #define ISIS_CYPHY_2_CAD_DLL_MIN_VERSION "1.2.0.0"
 #define ISIS_METRIC_FILE_VERSION "v1.1.0.0"

--- a/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.cpp
+++ b/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.cpp
@@ -1926,6 +1926,208 @@ namespace isis
 	}
 
 
+	ProError isis_ProOutputFileMdlnameWrite(	 ProMdl      model,
+                                     const ProFileName name,
+                                     ProImportExportFile   file_type,
+                                     ProAppData  arg1,
+                                     ProAppData  arg2,
+                                     ProAppData  arg3,
+                                     ProAppData  arg4 )
+											throw(isis::application_exception)
+	{
+
+		ProError err = ProOutputFileMdlnameWrite (  model,
+											 (wchar_t *)name,
+											 file_type,
+											 arg1,
+											 arg2,
+											 arg3,
+											 arg4 );
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			isis::MultiFormatString  name_multi( name);
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputFileMdlnameWrite returned ProError: %s(%d), Output File Name: %s",ProToolKitError_string(err).c_str(), err, (const char *)name_multi );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+
+	ProError isis_ProOutputAssemblyConfigurationIsSupported( ProIntf3DExportType file_type,
+           											ProOutputAssemblyConfiguration configuration,
+													ProBoolean*  is_supported)
+													throw(isis::application_exception)
+	{
+
+		ProError err =  ProOutputAssemblyConfigurationIsSupported(	file_type,
+           															configuration,
+																	is_supported);
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputAssemblyConfigurationIsSupported returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+
+	}
+
+
+	ProError   isis_ProOutputBrepRepresentationAlloc( ProOutputBrepRepresentation* representation)
+														throw(isis::application_exception)
+	{
+
+		ProError err =  ProOutputBrepRepresentationAlloc( representation);
+
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputBrepRepresentationAlloc returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+
+
+
+
+
+	ProError   isis_ProOutputBrepRepresentationFlagsSet(
+								ProOutputBrepRepresentation representation,
+								ProBoolean as_wireframe,
+								ProBoolean as_surfaces,
+								ProBoolean as_solid,
+								ProBoolean as_quilts)
+														throw(isis::application_exception)
+	{
+
+		ProError err =  ProOutputBrepRepresentationFlagsSet( representation, as_wireframe,
+															 as_surfaces, as_solid, as_quilts);
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputBrepRepresentationFlagsSet returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+	ProError   isis_ProOutputBrepRepresentationFree( ProOutputBrepRepresentation representation)
+																	throw(isis::application_exception)
+	{
+
+		ProError err = ProOutputBrepRepresentationFree( representation);
+
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputBrepRepresentationFree returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+
+
+
+	ProError   isis_ProOutputBrepRepresentationIsSupported( ProIntf3DExportType file_type,
+          													ProOutputBrepRepresentation representation,
+															ProBoolean*  is_supported)
+																	throw(isis::application_exception)
+	{
+
+		ProError err = ProOutputBrepRepresentationIsSupported( file_type, representation, is_supported);
+
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputBrepRepresentationIsSupported returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+
+
+	ProError   isis_ProOutputInclusionWithOptionsSet(	ProOutputInclusion inclusion,
+													double             *parameters,
+													int                config_flags)
+														throw(isis::application_exception)
+	{
+
+		ProError err =  ProOutputInclusionWithOptionsSet( inclusion, parameters, config_flags);
+
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputInclusionWithOptionsSet returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+
+	ProError   isis_ProOutputInclusionAlloc( ProOutputInclusion* inclusion)
+														throw(isis::application_exception)
+	{
+
+		ProError err =  ProOutputInclusionAlloc( inclusion);
+
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : isis_ProOutputInclusionAlloc returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+	ProError   isis_ProOutputInclusionFlagsSet( ProOutputInclusion inclusion,
+														 ProBoolean include_datums,
+														 ProBoolean include_blanked,
+														 ProBoolean include_facetted)
+														throw(isis::application_exception)
+	{
+
+		ProError err = ProOutputInclusionFlagsSet( inclusion, include_datums, include_blanked, include_facetted);
+
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputInclusionFlagsSet returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
+
+	ProError   isis_ProOutputInclusionFree (ProOutputInclusion inclusion)
+														throw(isis::application_exception)
+	{
+
+		ProError err =  ProOutputInclusionFree (inclusion);
+
+
+		if ( err != PRO_TK_NO_ERROR ) 
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf( err_str, "exception : ProOutputInclusionFree returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			throw isis::application_exception("C06089",err_str);  
+		}
+		return err;
+	}
+
 	ProError isis_ProIntf3DFileWrite(	ProSolid solid,
         								ProIntf3DExportType file_type,
 										ProPath output_file,
@@ -1936,7 +2138,7 @@ namespace isis
         								ProOutputLayerOptions layer_options )
 											throw(isis::application_exception)
 	{
-
+	
 		ProError err = ProIntf3DFileWrite (  solid,
 											 file_type,
 											 output_file,

--- a/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.h
+++ b/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.h
@@ -463,6 +463,61 @@ namespace isis
 												ProAppData  arg4 )
 											throw(isis::application_exception);
 
+
+	extern ProError isis_ProOutputFileMdlnameWrite(	ProMdl      model,
+												const ProFileName name,
+												ProImportExportFile   file_type,
+												ProAppData  arg1,
+												ProAppData  arg2,
+												ProAppData  arg3,
+												ProAppData  arg4 )
+											throw(isis::application_exception);
+
+	extern ProError isis_ProOutputAssemblyConfigurationIsSupported( ProIntf3DExportType file_type,
+           											ProOutputAssemblyConfiguration configuration,
+													ProBoolean*  is_supported)
+													throw(isis::application_exception);
+
+	extern ProError  isis_ProOutputBrepRepresentationAlloc( ProOutputBrepRepresentation* representation)
+														throw(isis::application_exception);
+
+	extern ProError   isis_ProOutputBrepRepresentationFlagsSet(
+								ProOutputBrepRepresentation representation,
+								ProBoolean as_wireframe,
+								ProBoolean as_surfaces,
+								ProBoolean as_solid,
+								ProBoolean as_quilts)
+														throw(isis::application_exception);
+
+	extern  ProError isis_ProOutputBrepRepresentationFree( ProOutputBrepRepresentation representation)
+																	throw(isis::application_exception);
+
+	extern ProError   isis_ProOutputBrepRepresentationIsSupported( ProIntf3DExportType file_type,
+          													ProOutputBrepRepresentation representation,
+															ProBoolean*  is_supported)
+															throw(isis::application_exception);
+
+	extern ProError  isis_ProOutputInclusionWithOptionsSet(	ProOutputInclusion inclusion,
+													double             *parameters,
+													int                config_flags)
+														throw(isis::application_exception);
+
+
+	extern ProError   isis_ProOutputInclusionAlloc( ProOutputInclusion* inclusion)
+														throw(isis::application_exception);
+
+
+	extern ProError   isis_ProOutputInclusionFlagsSet( ProOutputInclusion inclusion,
+														 ProBoolean include_datums,
+														 ProBoolean include_blanked,
+														 ProBoolean include_facetted)
+														throw(isis::application_exception);
+
+
+	extern ProError   isis_ProOutputInclusionFree (ProOutputInclusion inclusion)
+														throw(isis::application_exception);
+
+
 	extern ProError isis_ProIntf3DFileWrite(	ProSolid solid,
         								ProIntf3DExportType file_type,
 										ProPath output_file,

--- a/src/CyPhy2CAD_CSharp/MainForm.Designer.cs
+++ b/src/CyPhy2CAD_CSharp/MainForm.Designer.cs
@@ -143,7 +143,7 @@
             "AP203_E2_Single_File",
             "AP203_E2_Separate_Part_Files",
             "AP214_Single_File",
-            "AP214_E2_Seperate_Part_Files"});
+            "AP214_Separate_Part_Files"});
             this.clb_Step.Location = new System.Drawing.Point(12, 130);
             this.clb_Step.Name = "clb_Step";
             this.clb_Step.Size = new System.Drawing.Size(522, 79);

--- a/src/CyPhy2CAD_CSharp/MainForm.cs
+++ b/src/CyPhy2CAD_CSharp/MainForm.cs
@@ -167,7 +167,7 @@ namespace CyPhy2CAD_CSharp
                 CadOptionsHolder.AuxiliaryDirectory = "";
                 CadOptionsHolder.OutputDirectory = "";
                 CadOptionsHolder.UseProjectManifest = true;
-                CadOptionsHolder.StepFormats.Add("AP203_E2_Seperate_Part_Files");
+                CadOptionsHolder.StepFormats.Add("AP203_E2_Separate_Part_Files");
                 CadOptionsHolder.StepFormats.Add("AP203_E2_Single_File");
             }
         }        

--- a/src/CyPhy2CAD_CSharp/TestBenchModel/BallisticTestBench.cs
+++ b/src/CyPhy2CAD_CSharp/TestBenchModel/BallisticTestBench.cs
@@ -138,8 +138,8 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
         public override void TraverseTestBench(CyPhy.TestBenchType testBenchBase)
         {
             string stepFormat = "AP203_E2_Single_File";
-            if (!DataExchangeFormats.Contains(stepFormat))
-                DataExchangeFormats.Add(stepFormat);
+            if (!STEP_DataExchangeFormats.Contains(stepFormat, StringComparer.OrdinalIgnoreCase))
+                STEP_DataExchangeFormats.Add(stepFormat);
 
             CyPhy.BallisticTestBench testBench = testBenchBase as CyPhy.BallisticTestBench;
             if (testBench == null)

--- a/src/CyPhy2CAD_CSharp/TestBenchModel/BlastTestBench.cs
+++ b/src/CyPhy2CAD_CSharp/TestBenchModel/BlastTestBench.cs
@@ -113,8 +113,8 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
                 stepFormat = "AP203_E2_Single_File";
             }
 
-            if (!DataExchangeFormats.Contains(stepFormat))
-                DataExchangeFormats.Add(stepFormat);
+            if (!STEP_DataExchangeFormats.Contains(stepFormat, StringComparer.CurrentCultureIgnoreCase))
+                STEP_DataExchangeFormats.Add(stepFormat);
 
             // blast threat
             if (customCnt > 0)

--- a/src/CyPhy2CAD_CSharp/TestBenchModel/CFDTestBench.cs
+++ b/src/CyPhy2CAD_CSharp/TestBenchModel/CFDTestBench.cs
@@ -28,8 +28,8 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
 
         public override void TraverseTestBench(CyPhy.TestBenchType testBenchBase)
         {
-            // META-3195 - CFD needs Inventor format now instead of STL ASCII
-            STLDataExchangeFormats.Add("Inventor");
+            // META-3195 - CFD needs Inventor format now instead of STL - Stereolithography_ASCII
+            NonSTEP_DataExchangeFormats.Add("Inventor");
 
             CyPhy.CFDTestBench testBench = testBenchBase as CyPhy.CFDTestBench;
             if (testBench == null)

--- a/src/CyPhy2CAD_CSharp/TestBenchModel/FEATestBench.cs
+++ b/src/CyPhy2CAD_CSharp/TestBenchModel/FEATestBench.cs
@@ -147,15 +147,15 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
         public override void TraverseTestBench(CyPhy.TestBenchType testBenchBase)
         {           
             string stepFormat = "AP203_E2_Single_File";
-            if (!DataExchangeFormats.Contains(stepFormat))
-                DataExchangeFormats.Add(stepFormat);
+            if (!STEP_DataExchangeFormats.Contains(stepFormat, StringComparer.CurrentCultureIgnoreCase))
+                STEP_DataExchangeFormats.Add(stepFormat);
 
             CyPhy.CADTestBench testBench = testBenchBase as CyPhy.CADTestBench;
             if (testBench == null)
                 testBench = CyPhyClasses.CADTestBench.Cast(testBenchBase.Impl);
 
             if (testBench.Attributes.SolverType == CyPhyClasses.CADTestBench.AttributesClass.SolverType_enum.PATRAN_NASTRAN)
-                STLDataExchangeFormats.Add("Parasolid");
+                NonSTEP_DataExchangeFormats.Add("Parasolid");
 
             this.CyphyTestBenchRef = testBench;
             base.TraverseTestBench(testBenchBase);

--- a/src/CyPhy2CAD_CSharp/TestBenchModel/KinematicTestBench.cs
+++ b/src/CyPhy2CAD_CSharp/TestBenchModel/KinematicTestBench.cs
@@ -47,7 +47,7 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
 
             base.TraverseTestBench(testBenchBase);
 
-            //STLDataExchangeFormats.Add("Parasolid");
+            //NonSTEP_DataExchangeFormats.Add("Parasolid");
 
             Name = testBench.Name;
             SimulationStep = testBench.Attributes.SimulationResolution;

--- a/src/CyPhy2CAD_CSharp/TestBenchModel/TestBenchBase.cs
+++ b/src/CyPhy2CAD_CSharp/TestBenchModel/TestBenchBase.cs
@@ -66,8 +66,8 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
         public static readonly string CADAssemblyFile = "CADAssembly.xml";
         public static readonly string CADAnalysisFile = "CADAnalysis.xml";
 
-        public List<string> DataExchangeFormats { get; set; }
-        public List<string> STLDataExchangeFormats { get; set; }
+        public List<string> STEP_DataExchangeFormats { get; set; }
+        public List<string> NonSTEP_DataExchangeFormats { get; set; }
         public List<string> SpecialDataFormatInstructions { get; set; }
         public DataRep.CADContainer cadDataContainer    { get; set; }
         public string OutputDirectory { get; set; }
@@ -101,21 +101,21 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
                              string projectdir,
                              bool auto = false)
         {
-            DataExchangeFormats = new List<string>();
-            DataExchangeFormats.AddRange(cadSetting.StepFormats);
-            STLDataExchangeFormats = new List<string>();
+            STEP_DataExchangeFormats = new List<string>();
+            STEP_DataExchangeFormats.AddRange(cadSetting.StepFormats);
+            NonSTEP_DataExchangeFormats = new List<string>();
             if (cadSetting.OtherDataFormat.STLAscii == true)
             {
-                STLDataExchangeFormats.Add("ASCII");
+                NonSTEP_DataExchangeFormats.Add("Stereolithography_ASCII");
             }
 
             if (cadSetting.OtherDataFormat.STLBinary == true)
             {
-                STLDataExchangeFormats.Add("Binary");
+                NonSTEP_DataExchangeFormats.Add("Stereolithography_Binary");
             }
             if (cadSetting.OtherDataFormat.Inventor == true)
             {
-                STLDataExchangeFormats.Add("Inventor");
+                NonSTEP_DataExchangeFormats.Add("Inventor");
             }
             SpecialDataFormatInstructions = new List<string>();
             if (cadSetting.SpecialInstructions.LeafAssembliesMetric == true)
@@ -154,13 +154,16 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
 
         public string GetParameterValue(CyPhy.TestBenchType testBench, string paramname)
         {
-            var param = testBench.Children.ParameterCollection.Where(p => p.Name == paramname);
+            //var param = testBench.Children.ParameterCollection.Where(p => p.Name == paramname);
+            // R. Owens, 5/11/2017 Make case insentive
+            var param = testBench.Children.ParameterCollection.Where(p => p.Name.Equals(paramname, StringComparison.CurrentCultureIgnoreCase) );
             if (param.Any())
             {
                 return param.First().Attributes.Value;
             }
             return null;
         }
+
 
         public virtual void TraverseTestBench(CyPhy.TestBenchType testBench)
         {
@@ -176,47 +179,52 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
             exportParameterName = "EXPORT_STEP_AP203_SINGLE_FILE";
             exportFormat =                    "AP203_Single_File";
             if (GetParameterValue(testBench, exportParameterName) != null )
-                if (!DataExchangeFormats.Contains(exportFormat)) DataExchangeFormats.Add(exportFormat);
+                if (!STEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) STEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_STEP_AP203_E2_SINGLE_FILE";
             exportFormat =                    "AP203_E2_Single_File";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!DataExchangeFormats.Contains(exportFormat)) DataExchangeFormats.Add(exportFormat);
+                if (!STEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) STEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_STEP_AP203_E2_SEPARATE_PART_FILES";
             exportFormat =                    "AP203_E2_Separate_Part_Files";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!DataExchangeFormats.Contains(exportFormat)) DataExchangeFormats.Add(exportFormat);
+                if (!STEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) STEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_STEP_AP214_SINGLE_FILE";
             exportFormat =                    "AP214_Single_File";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!DataExchangeFormats.Contains(exportFormat)) DataExchangeFormats.Add(exportFormat);
+                if (!STEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) STEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_STEP_AP214_SEPARATE_PART_FILES";
             exportFormat =                    "AP214_Separate_Part_Files";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!DataExchangeFormats.Contains(exportFormat)) DataExchangeFormats.Add(exportFormat);
+                if (!STEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) STEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_STEREOLITHOGRAPHY_ASCII";
-            exportFormat =                                 "ASCII";
+            exportFormat =               "Stereolithography_ASCII";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!STLDataExchangeFormats.Contains(exportFormat)) STLDataExchangeFormats.Add(exportFormat);
+                if (!NonSTEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) NonSTEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_STEREOLITHOGRAPHY_BINARY";
-            exportFormat =                                 "Binary";
+            exportFormat =               "Stereolithography_Binary";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!STLDataExchangeFormats.Contains(exportFormat)) STLDataExchangeFormats.Add(exportFormat);
+                if (!NonSTEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) NonSTEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_INVENTOR";
             exportFormat =               "Inventor";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!STLDataExchangeFormats.Contains(exportFormat)) STLDataExchangeFormats.Add(exportFormat);
+                if (!NonSTEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) NonSTEP_DataExchangeFormats.Add(exportFormat);
 
             exportParameterName = "EXPORT_PARASOLID";
             exportFormat =               "Parasolid";
             if (GetParameterValue(testBench, exportParameterName) != null)
-                if (!STLDataExchangeFormats.Contains(exportFormat)) STLDataExchangeFormats.Add(exportFormat);
+                if (!NonSTEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) NonSTEP_DataExchangeFormats.Add(exportFormat);
+
+            exportParameterName = "EXPORT_DXF_2013";
+            exportFormat = "DXF_2013";
+            if (GetParameterValue(testBench, exportParameterName) != null)
+                if (!NonSTEP_DataExchangeFormats.Contains(exportFormat, StringComparer.CurrentCultureIgnoreCase)) NonSTEP_DataExchangeFormats.Add(exportFormat);
 
 
             foreach (var param in testBench.Children.ParameterCollection.Where(p => p.Name == "PROCESSINGINSTRUCTION"))
@@ -268,13 +276,13 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
 
         public void AddDataExchangeFormatToXMLOutput(CAD.AssembliesType assembliesRoot)
         {
-            if (DataExchangeFormats.Count > 0 || STLDataExchangeFormats.Count > 0 || SpecialDataFormatInstructions.Count > 0)
+            if (STEP_DataExchangeFormats.Count > 0 || NonSTEP_DataExchangeFormats.Count > 0 || SpecialDataFormatInstructions.Count > 0)
             {
                 CAD.DataExchangeType dataexchangeout = new CAD.DataExchangeType();
                 dataexchangeout._id = UtilityHelpers.MakeUdmID();
 
                 List<CAD.STEPFormatType> exchangelist = new List<CAD.STEPFormatType>();
-                foreach (var item in DataExchangeFormats)
+                foreach (var item in STEP_DataExchangeFormats)
                 {
                     CAD.STEPFormatType formatout = new CAD.STEPFormatType();
                     formatout._id = UtilityHelpers.MakeUdmID();
@@ -283,22 +291,37 @@ namespace CyPhy2CAD_CSharp.TestBenchModel
                 }
 
                 List<CAD.NonSTEPFormatType> stllist = new List<CAD.NonSTEPFormatType>();
-                foreach (var item in STLDataExchangeFormats)
+                foreach (var item in NonSTEP_DataExchangeFormats)
                 {
                     CAD.NonSTEPFormatType formatout = new CAD.NonSTEPFormatType();
                     formatout._id = UtilityHelpers.MakeUdmID();
 
-                    if (item == "Inventor" || item == "Parasolid")
+                    switch (item.ToLower())
                     {
-                        formatout.FormatType = item;
-                        formatout.FormatSubType = "";
-                    }
-                    else
-                    {
-                        formatout.FormatType = "Stereolithography";
-                        formatout.FormatSubType = item.ToUpper();
-                    }
+                        case "inventor":
+                        case "parasolid":
+                            formatout.FormatType = item;
+                            formatout.FormatSubType = "";
+                            break;
+                        case "stereolithography_ascii":
+                            formatout.FormatType = "Stereolithography";
+                            formatout.FormatSubType = "ASCII";
+                            break;
+                        case "stereolithography_binary":
+                            formatout.FormatType = "Stereolithography";
+                            formatout.FormatSubType = "BINARY";
+                            break;
+                        case "dxf_2013":
+                            formatout.FormatType = "DXF";
+                            formatout.FormatSubType = "2013";
+                            break;
 
+                        default:
+                            Logger.Instance.AddLogMessage("AddDataExchangeFormatToXMLOutput received an unknown NonSTEP_DataExchangeFormat, recieved value: " + item 
+                                + "  This would be due to a programming error/bug.", Severity.Error);
+                            break;
+
+                    }
                     stllist.Add(formatout);
                 }
 


### PR DESCRIPTION
Added support for exporting DXF format.  Exporting Wavefront is not supported by the toolkit. DXF exports only work with Solid models.  Surface models will result in a DXF file that is empty. Switched from using the Creo function ProOutputFileWrite (deprecated as of Creo 3.0) to ProOutputFileMdlnameWrite.
