### PR TITLE
CAD: read Units for CyPhy CADParameters. Read units for Creo Paramete…

### DIFF
--- a/src/CADAssembler/CADCommonFunctions/CADCommonFunctions.vcxproj
+++ b/src/CADAssembler/CADCommonFunctions/CADCommonFunctions.vcxproj
@@ -88,7 +88,6 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>C4996;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/CADAssembler/CADCommonFunctions/cc_CommonStructures.h
+++ b/src/CADAssembler/CADCommonFunctions/cc_CommonStructures.h
@@ -303,6 +303,7 @@ namespace isis
 		MultiFormatString		name;   /**<  Parameter name. */
 		e_CADParameterType		type;   /**<  CAD_FLOAT, CAD_INTEGER, CAD_BOOLEAN */ 
 		MultiFormatString		value;  /**<   Parameter value (e.g 1.4, 34...) */
+		MultiFormatString		units;
 
 		CADParameter() : name(CAD_NAME_SIZE - 1), value(CAD_LINE_SIZE-1){}
 

--- a/src/CADAssembler/CADCommonFunctions/cc_XMLtoCADStructures.cpp
+++ b/src/CADAssembler/CADCommonFunctions/cc_XMLtoCADStructures.cpp
@@ -92,7 +92,7 @@ void stream_AssemblyTree( vector<AssemblyInterface::CADComponent>		&in_CADCompon
 					AssemblyInterface::Units units = ck->Units_child();
 					if ( units != Udm::null)
 					{
-						out_Stream << endl << in_Indent << "	  Units.Value             " << std::string(units.Value());     
+						out_Stream << endl << in_Indent << "        Units.Value           " << std::string(units.Value());
 					}
 
 				}  //for ( AssemblyType::CADComponent_type::ParametricParameters_type::CADParameter_const_iterator k( i->ParametricParameters().get().CADParameter().begin());
@@ -184,6 +184,11 @@ void SetCADParametricParameterAttributes( const AssemblyInterface::CADComponent	
 			CADParameter_temp.name  =  ci->Name();
 			CADParameter_temp.type  =  CADParameterType_enum(  ci->Type() );
 			CADParameter_temp.value =  ci->Value();       // this must remain a string for now, will convert when
+			auto units = static_cast<AssemblyInterface::Units>(ci->Units_child());
+			if (units)
+			{
+				CADParameter_temp.units = static_cast<std::string>(units.Value());
+			}
 
 			out_CADComponentData_map[ID].parametricParameters.push_back(CADParameter_temp);
 			out_CADComponentData_map[ID].parametricParametersPresent = true;

--- a/src/CADAssembler/CADCreoParametricCommonFunctions/CommonFunctions.cpp
+++ b/src/CADAssembler/CADCreoParametricCommonFunctions/CommonFunctions.cpp
@@ -363,7 +363,7 @@ void RetrieveUnits( //cad::CadFactoryAbstract		&in_Factory,
 void RetrieveUnits_withDescriptiveErrorMsg( 
 					//cad::CadFactoryAbstract							&in_Factory,
 					const std::string								&in_ComponentInstanceID,
-					std::map<std::string, isis::CADComponentData>	&in_CADComponentData_map,  
+					isis::CADComponentData							&in_CADComponentData,
 					CADModelUnits									&out_CADModelUnits )
 											throw(isis::application_exception)
 
@@ -373,7 +373,7 @@ void RetrieveUnits_withDescriptiveErrorMsg(
 	try
 	{
 		RetrieveUnits(	//in_Factory,
-						in_CADComponentData_map[in_ComponentInstanceID].cADModel_hdl,
+						in_CADComponentData.cADModel_hdl,
 						out_CADModelUnits ); 
 
 	}
@@ -382,7 +382,7 @@ void RetrieveUnits_withDescriptiveErrorMsg(
 		std::stringstream errorString;
 		errorString << "Error retrieving model units:" <<  std::endl <<
 						"   ComponentInstanceID: " << in_ComponentInstanceID <<  std::endl <<
-						"   ModelName:           " << in_CADComponentData_map[in_ComponentInstanceID].name <<  std::endl <<
+						"   ModelName:           " << in_CADComponentData.name <<  std::endl <<
 						"   Error:               " << exc.what();
 		throw isis::application_exception(errorString.str());
 	}

--- a/src/CADAssembler/CADCreoParametricCommonFunctions/CommonFunctions.h
+++ b/src/CADAssembler/CADCreoParametricCommonFunctions/CommonFunctions.h
@@ -128,7 +128,7 @@ namespace isis
 	void RetrieveUnits_withDescriptiveErrorMsg( 
 				//cad::CadFactoryAbstract							&in_Factory,
 				const std::string								&in_ComponentInstanceID,
-				std::map<std::string, isis::CADComponentData>	&in_CADComponentData_map,
+				isis::CADComponentData							&in_CADComponentData,
 				CADModelUnits									&out_CADModelUnits  )
 													throw(isis::application_exception);
 

--- a/src/CADAssembler/CADCreoParametricCommonFunctions/ParametricParameters.h
+++ b/src/CADAssembler/CADCreoParametricCommonFunctions/ParametricParameters.h
@@ -12,6 +12,7 @@
 #include <isis_application_exception.h>
 #include <isis_ptc_toolkit_functions.h>
 #include <isis_include_ptc_headers.h>
+#include "cc_CommonStructures.h"
 #include <CreoStringToEnumConversions.h>
 #include <string>
 
@@ -74,10 +75,12 @@ namespace isis
 void SetParametricParameter(  
 				const std::string	&in_model_name,
 				ProMdl				*in_p_model, 
-				const std::string   in_ParameterName,
+				const std::string   &in_ParameterName,
 				//const std::string	in_ParameterType,
 				e_CADParameterType	in_ParameterType,
-				const std::string   in_ParameterValue)
+				const std::string   &in_ParameterValue,
+				const std::string   &in_ParameterUnits,
+				bool                is_mmKs)
 									throw (isis::application_exception);
 
 
@@ -159,6 +162,10 @@ ProError SetParametricParameter(
 
 
 
+void ParametricParameter_WarnForPartUnitsMismatch(
+	isis::CADComponentData &in_cadata,
+	bool *out_is_mmKs)
+	throw (isis::application_exception);
 
 } // End namespace isis
 

--- a/src/CADAssembler/CADCreoParametricCreateAssemblyFunctions/BuildAssembly.cpp
+++ b/src/CADAssembler/CADCreoParametricCreateAssemblyFunctions/BuildAssembly.cpp
@@ -634,7 +634,7 @@ void Add_Subassemblies_and_Parts(
 				if( err == PRO_TK_E_NOT_FOUND)
 					 isis::isis_ProParameterCreate(&assembled_feat_handle, name, &value, &param);
 				else
-					 isis::isis_ProParameterValueSet(&param, &value);
+					 isis::isis_ProParameterValueWithUnitsSet(&param, &value, nullptr);
 
 			}
 

--- a/src/CADAssembler/CADCreoParametricCreateAssemblyFunctions/CADFactoryCreo.cpp
+++ b/src/CADAssembler/CADCreoParametricCreateAssemblyFunctions/CADFactoryCreo.cpp
@@ -1352,7 +1352,7 @@ void ModelOperationsCreo::retrieveCADModelUnits(
 
 	RetrieveUnits_withDescriptiveErrorMsg(	//in_Factory,
 											in_ComponentInstanceID,
-											in_CADComponentData_map,  
+											in_CADComponentData_map[in_ComponentInstanceID],
 											out_CADModelUnits );
 
 

--- a/src/CADAssembler/CADCreoParametricCreateAssemblyFunctions/SetCADModelParameters.cpp
+++ b/src/CADAssembler/CADCreoParametricCreateAssemblyFunctions/SetCADModelParameters.cpp
@@ -28,6 +28,10 @@ void ApplyParametricParameters( std::list<std::string>                          
 
 		if ( cadata->parametricParametersPresent )
 		{
+			ProMdl* p_model = (ProMdl*)cadata->cADModel_ptr_ptr;
+			bool is_mmKs;
+			ParametricParameter_WarnForPartUnitsMismatch(*cadata, &is_mmKs);
+
 			for( std::list<CADParameter>::const_iterator p( cadata->parametricParameters.begin());
 			p != cadata->parametricParameters.end();
 			++ p )
@@ -40,7 +44,7 @@ void ApplyParametricParameters( std::list<std::string>                          
 				isis_LOG(lg, isis_FILE, isis_INFO) << "    p->value:  " <<	p->value;
 				try 
 				{
-					SetParametricParameter( ModelNameWithSuffix, cadata->cADModel_ptr_ptr, p->name, p->type, p->value);
+					SetParametricParameter( ModelNameWithSuffix, cadata->cADModel_ptr_ptr, p->name, p->type, p->value, p->units, is_mmKs);
 
 				} catch (isis::application_exception &ex)
 				{

--- a/src/CADAssembler/CADCreoParametricMetaLink/AssemblyEditingViaLink.cpp
+++ b/src/CADAssembler/CADCreoParametricMetaLink/AssemblyEditingViaLink.cpp
@@ -815,64 +815,58 @@ void MetaLinkAssemblyEditor::ModifyParameters(const std::string  &in_ComponentIn
 
     // Verify in_ComponentInstanceID does not exists.  If it does exist, then an attempt is
     // being made to modify a parameter on a component that does not exist
-    if(m_CADComponentData_map.find(in_ComponentInstanceID) == m_CADComponentData_map.end())
+    auto in_ComponentInstanceIt = m_CADComponentData_map.find(in_ComponentInstanceID);
+    if(in_ComponentInstanceIt == m_CADComponentData_map.end())
     {
         std::stringstream errorString;
         errorString << "MetaLinkAssemblyEditor::ModifyParameters invoked, but in_ComponentInstanceID does not exist in the assembly. "
                     << "A ComponentInstanceID must exist before a parameter can be modifed on that component. in_ComponentInstanceID: " << in_ComponentInstanceID;
         throw isis::application_exception("C08010",errorString);
     }
+    auto& in_ComponentInstance = in_ComponentInstanceIt->second;
     /////////////////////////////
     // End Input Data Checks
     /////////////////////////////
 
-    // Verify in_ComponentInstanceID is not an empty string
-    if(in_ComponentInstanceID.size() == 0)
-    {
-        std::stringstream errorString;
-        errorString << "MetaLinkAssemblyEditor::ModifyParameters invoked, but in_ComponentInstanceID is an empty string."
-                    << "A ComponentInstanceID must exist before a constraint can be added.";
-        throw isis::application_exception("C08011",errorString);
-    }
-
-    std::string modelNameWithSuffix = AmalgamateModelNameWithSuffix(
-                                          m_CADComponentData_map[in_ComponentInstanceID].name,
-                                          m_CADComponentData_map[in_ComponentInstanceID].modelType);
+    std::string modelNameWithSuffix = AmalgamateModelNameWithSuffix(in_ComponentInstance.name, in_ComponentInstance.modelType);
 
     isis_LOG(lg, isis_FILE, isis_INFO) << "Internal data structure parameter values BEFORE modification:";
-    for each(CADParameter i in m_CADComponentData_map[in_ComponentInstanceID].parametricParameters)
+    for each(CADParameter i in in_ComponentInstance.parametricParameters)
     {
         isis_LOG(lg, isis_FILE, isis_INFO) << i;
     }
 
+    ProMdl* p_model = (ProMdl*)in_ComponentInstance.cADModel_ptr_ptr;
+    bool is_mmKs;
+    ParametricParameter_WarnForPartUnitsMismatch(in_ComponentInstance, &is_mmKs);
     // Change the paraqmeters
     for each(CADParameter i in in_Parameters)
     {
         SetParametricParameter(modelNameWithSuffix,
-                               m_CADComponentData_map[in_ComponentInstanceID].cADModel_ptr_ptr,
-                               i.name, i.type, i.value);
+			in_ComponentInstance.cADModel_ptr_ptr,
+                               i.name, i.type, i.value, i.units, is_mmKs); // FIXME
     }
 
     bool regenerationSucceeded;
-    isis::RegenerateModel(static_cast<ProSolid>(m_CADComponentData_map[in_ComponentInstanceID].cADModel_hdl),
-                          m_CADComponentData_map[in_ComponentInstanceID].name,
-                          m_CADComponentData_map[in_ComponentInstanceID].componentID,
-                          regenerationSucceeded);
+    isis::RegenerateModel(static_cast<ProSolid>(in_ComponentInstance.cADModel_hdl),
+							in_ComponentInstance.name,
+							in_ComponentInstance.componentID,
+							regenerationSucceeded);
 
     isis::isis_ProWindowRepaint(windowID);
 
-    // We must update the parameters in m_CADComponentData_map[in_ComponentInstanceID].parametricParameters
+    // We must update the parameters in in_ComponentInstance.parametricParameters
     // as follows:
     //    a) if the parameter already exists, must update its value
     //    b) if the parameter does not exist, add it
     for each(CADParameter i in in_Parameters)
     {
         std::list<CADParameter>::iterator itr;
-        itr = find(m_CADComponentData_map[in_ComponentInstanceID].parametricParameters.begin(),
-                   m_CADComponentData_map[in_ComponentInstanceID].parametricParameters.end(),
+        itr = find(in_ComponentInstance.parametricParameters.begin(),
+					in_ComponentInstance.parametricParameters.end(),
                    i);
 
-        if(itr != m_CADComponentData_map[in_ComponentInstanceID].parametricParameters.end())
+        if(itr != in_ComponentInstance.parametricParameters.end())
         {
             // Found, must modify
             itr->type    = i.type;    // would be an error if the types are different
@@ -881,12 +875,12 @@ void MetaLinkAssemblyEditor::ModifyParameters(const std::string  &in_ComponentIn
         else
         {
             // Not found, must add
-            m_CADComponentData_map[in_ComponentInstanceID].parametricParameters.push_back(i);
+			in_ComponentInstance.parametricParameters.push_back(i);
         }
     }
 
     isis_LOG(lg, isis_FILE, isis_INFO) << "Internal data structure parameter values AFTER modification:";
-    for each(CADParameter i in m_CADComponentData_map[in_ComponentInstanceID].parametricParameters)
+    for each(CADParameter i in in_ComponentInstance.parametricParameters)
     {
         isis_LOG(lg, isis_FILE, isis_INFO) << i;
     }

--- a/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_include_ptc_headers.h
+++ b/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_include_ptc_headers.h
@@ -47,6 +47,8 @@ extern "C"
 #include <ProFit.h>
 #include <ProIntf3Dexport.h>
 #include <ProSurface.h>
+#include <ProMdlUnits.h>
+#include <ProRelSet.h>
 //#include <TestError.h>
 }
 

--- a/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.cpp
+++ b/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.cpp
@@ -703,6 +703,16 @@ namespace isis
 		return err;
 	}
 
+	void isis_ProError_Throw(const char* func_name, ProError err)
+	{
+		if (err != PRO_TK_NO_ERROR)
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf(err_str, "exception : %s returned ProError: %s(%d)", func_name, ProToolKitError_string(err).c_str(), err);
+			throw isis::application_exception("C06999", err_str);
+		}
+	}
+
 	ProError isis_ProArrayAlloc ( int n_objs,
                                   int obj_size,
                                   int reallocation_size,
@@ -1451,23 +1461,24 @@ namespace isis
 	}
 
 
-	ProError isis_ProParameterValueSet(	ProParameter   *param, 
-										ProParamvalue  *proval )
-											throw(isis::application_exception)
+	ProError isis_ProParameterValueWithUnitsSet(ProParameter   *param,
+												ProParamvalue  *proval,
+												ProUnititem    *units)
+													throw(isis::application_exception)
 	{
 
-		ProError err = ProParameterValueSet ( param, proval );
+		ProError err = ProParameterValueWithUnitsSet ( param, proval, units );
 
 		if ( err != PRO_TK_NO_ERROR ) 
 		{
 			char  err_str[ERROR_STRING_BUFFER_LENGTH];
-			sprintf( err_str, "exception : ProParameterValueSet returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			sprintf( err_str, "exception : ProParameterValueWithUnitsSet returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
 			throw isis::application_exception("C06065",err_str);  
 		}
 		return err;
 	}
 
-	ProError isis_ProParameterCreate(	ProModelitem  *owner, 
+	ProError isis_ProParameterCreate(	ProModelitem  *owner,
 										const ProName        name, 
 										ProParamvalue *proval, 
 										ProParameter  *param )
@@ -1485,7 +1496,7 @@ namespace isis
 	}
 
 	ProError isis_ProParameterValueGet(	ProParameter   *param, 
-                                      ProParamvalue  *proval )
+										ProParamvalue  *proval )
 											throw(isis::application_exception)
 	{
 
@@ -1501,18 +1512,19 @@ namespace isis
 	}
 
 
-  	ProError isis_ProParameterScaledvalueSet(ProParameter   *param, 
-                                            ProParamvalue  *proval,
-                                            ProUnititem    *units)
+	ProError isis_ProUnitConversionCalculate(ProUnititem *from,
+		ProUnititem *to,
+		ProUnitConversion *conversion,
+		wchar_t *from_name)
 										throw(isis::application_exception)
 	{
 
-		ProError err = ProParameterScaledvalueSet ( param, proval, units );
+		ProError err = ProUnitConversionCalculate( from, to, conversion );
 
 		if ( err != PRO_TK_NO_ERROR ) 
 		{
 			char  err_str[ERROR_STRING_BUFFER_LENGTH];
-			sprintf( err_str, "exception : ProParameterScaledvalueSet returned ProError: %s(%d)",ProToolKitError_string(err).c_str(), err );
+			sprintf( err_str, "exception : ProUnitConversionCalculate returned ProError: %s(%d). Could not convert from %S to %S", ProToolKitError_string(err).c_str(), err, from_name, to->name);
 			throw isis::application_exception("C06068",err_str);  
 		}
 		return err;
@@ -1537,6 +1549,38 @@ namespace isis
 		return err;
 	}
 
+	ProError isis_ProUnitCreateByExpression(ProMdl			mdl,
+		const ProName   unit_name,
+		const ProPath	expression,
+		ProUnititem*	unit)
+		throw(isis::application_exception)
+	{
+
+		ProError err = ProUnitCreateByExpression(mdl, const_cast<wchar_t*>(unit_name), const_cast<wchar_t*>(expression), unit);
+
+		if (err != PRO_TK_NO_ERROR)
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf(err_str, "exception : ProUnitCreateByExpression returned ProError: %s(%d)", ProToolKitError_string(err).c_str(), err);
+			throw isis::application_exception("C06069", err_str);
+		}
+		return err;
+	}
+
+	ProError isis_ProUnitDelete(ProUnititem*	unit)
+		throw(isis::application_exception)
+	{
+
+		ProError err = ProUnitDelete(unit);
+
+		if (err != PRO_TK_NO_ERROR)
+		{
+			char  err_str[ERROR_STRING_BUFFER_LENGTH];
+			sprintf(err_str, "exception : ProUnitDelete returned ProError: %s(%d)", ProToolKitError_string(err).c_str(), err);
+			throw isis::application_exception("C06069", err_str);
+		}
+		return err;
+	}
 
 	ProError isis_ProMacroLoad(	wchar_t* macro )
 										throw(isis::application_exception)

--- a/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.h
+++ b/src/CADAssembler/CADCreoParametricToolkitFunctions/isis_ptc_toolkit_functions.h
@@ -164,6 +164,8 @@ namespace isis
 	extern ProError isis_ProMdlToModelitem (	ProMdl mdl, 
 										ProModelitem* p_model_item ) throw(isis::application_exception);
 
+	extern void isis_ProError_Throw(const char* func_name, ProError err);
+
 	extern ProError isis_ProArrayAlloc ( int n_objs,
                                   int obj_size,
                                   int reallocation_size,
@@ -343,8 +345,8 @@ namespace isis
 												ProParameter *param )
 													throw(isis::application_exception);
 
-	extern	ProError isis_ProParameterValueSet(	ProParameter   *param, 
-										ProParamvalue  *proval )
+	extern	ProError isis_ProParameterValueWithUnitsSet(	ProParameter   *param,
+										ProParamvalue  *proval, ProUnititem *units )
 											throw(isis::application_exception);
 
 	extern ProError isis_ProParameterCreate(	ProModelitem  *owner, 
@@ -357,9 +359,10 @@ namespace isis
                                       ProParamvalue  *proval )
 											throw(isis::application_exception);
 
-	extern 	ProError isis_ProParameterScaledvalueSet(ProParameter   *param, 
-                                            ProParamvalue  *proval,
-                                            ProUnititem    *units)
+	extern 	ProError isis_ProUnitConversionCalculate(ProUnititem *from,
+                                            ProUnititem *to,
+                                            ProUnitConversion *conversion,
+											wchar_t *from_name)
 										throw(isis::application_exception);
 
 	 extern	ProError isis_ProUnitInit(	ProMdl        mdl,
@@ -367,7 +370,16 @@ namespace isis
 										ProUnititem*  unit)
 										throw(isis::application_exception);
 
-	 extern	ProError isis_ProSolidMassPropertyGet(ProSolid solid,
+	extern	ProError isis_ProUnitCreateByExpression(ProMdl			mdl,
+													const ProName   unit_name,
+													const ProPath	expression,
+													ProUnititem*	unit)
+													throw(isis::application_exception);
+
+	extern	ProError isis_ProUnitDelete(ProUnititem*	unit)
+		throw(isis::application_exception);
+
+	extern	ProError isis_ProSolidMassPropertyGet(ProSolid solid,
                                           const ProName  csys_name,
                                           ProMassProperty* mass_prop )
 										throw(isis::application_exception);

--- a/src/CyPhyToolbox/FormulaTraverse.cpp
+++ b/src/CyPhyToolbox/FormulaTraverse.cpp
@@ -1495,7 +1495,7 @@ void NewTraverser::EvaluateCADParameters()
 				}
 
 			}
-			// if unit is not specified, assume mm kg s deg
+			// if unit is not specified, assume mm kg s deg (mmKs)
 			if (cyphy_unit == Udm::null && unit_name == "")
 			{
 				auto lengthRep = UnitUtil::DimensionRep::zeroes;
@@ -1521,6 +1521,8 @@ void NewTraverser::EvaluateCADParameters()
 
 				auto angleRep = UnitUtil::DimensionRep::zeroes;
 				// FIXME: default to deg
+
+				ci->Unit() = unit_name;
 			}
 			if (cyphy_unit == Udm::null && unit_name != "")
 			{


### PR DESCRIPTION
…rs. Warn for Creo Parameters without units and non-mmKs .prt, as this results in wrong dimensions