### PR TITLE
OPENMETA-748 Terminate background Creo process when CAD import progress dialog cancel button is clicked

### DIFF
--- a/src/CyPhyComponentAuthoring/Modules/CADModelImport.cs
+++ b/src/CyPhyComponentAuthoring/Modules/CADModelImport.cs
@@ -220,6 +220,9 @@ namespace CyPhyComponentAuthoring.Modules
                             var result = progress.ShowDialog((IWin32Window)sender);
                             if (result == DialogResult.Cancel)
                             {
+                                firstProc.Kill();
+                                firstProc.WaitForExit();
+                                this.Logger.WriteInfo("CAD model import cancelled by user.");
                                 cleanup(null, true);
                                 return;
                             }


### PR DESCRIPTION
This prevents a GME crash when we try to write that background process's stdout/stderr to the GME console.

Doing this as a PR because I'm not sure if there's a reason why this process wasn't being cleaned up--  are there side effects to killing Creo?  (like not cleaning up checked out licenses, maybe?)